### PR TITLE
ci(pi): kernai/refinery-parent-images:v2.0.0-exec-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v1.23.0-exec-env
+FROM kernai/refinery-parent-images:v2.0.0-exec-env
 
 COPY requirements.txt .
 


### PR DESCRIPTION
Automated parent image release for:
- https://github.com/code-kern-ai/refinery-exec-env-parent-image/releases/tag/v2.0.0
- https://github.com/code-kern-ai/refinery-exec-env-parent-image/pull/v2.0.0